### PR TITLE
feat: add Dependabot auto-merge action and configuration [skip changeset check]

### DIFF
--- a/.github/actions/dependabot-auto-merge/action.yml
+++ b/.github/actions/dependabot-auto-merge/action.yml
@@ -1,0 +1,61 @@
+name: Dependabot Auto Merge
+description: Automatically merge Dependabot PRs that pass all checks and have the required approvals.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  permissions:
+    contents: write
+    pull-requests: write
+  
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide if eligible (patch/minor)
+        id: elig
+        run: |
+         
+          echo "Checking if PR #${{ github.event.pull_request.number }} is eligible for auto-merge..."
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY="${{ github.event.pull_request.body }}"
+          echo "PR Title: $PR_TITLE"
+          echo "PR Body: $PR_BODY"
+
+          # Extract version numbers from title using regex
+          if [[ "$PR_TITLE" =~ bump.*from[[:space:]]+([0-9]+)\.([0-9]+)\.([0-9]+)[[:space:]]+to[[:space:]]+([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            FROM_MAJOR=${BASH_REMATCH[1]}
+            FROM_MINOR=${BASH_REMATCH[2]}
+            FROM_PATCH=${BASH_REMATCH[3]}
+            TO_MAJOR=${BASH_REMATCH[4]}
+            TO_MINOR=${BASH_REMATCH[5]}
+            TO_PATCH=${BASH_REMATCH[6]}
+            
+            echo "Version change: $FROM_MAJOR.$FROM_MINOR.$FROM_PATCH → $TO_MAJOR.$TO_MINOR.$TO_PATCH"
+            
+            # Check if it's a patch update (same major.minor, different patch)
+            if [[ $FROM_MAJOR -eq $TO_MAJOR && $FROM_MINOR -eq $TO_MINOR && $FROM_PATCH -lt $TO_PATCH ]]; then
+              echo "✅ Patch update detected - eligible for auto-merge"
+              echo "eligible=true" >> $GITHUB_OUTPUT
+            # Check if it's a minor update (same major, incremented minor, patch reset to 0 or similar)
+            elif [[ $FROM_MAJOR -eq $TO_MAJOR && $FROM_MINOR -lt $TO_MINOR ]]; then
+              echo "✅ Minor update detected - eligible for auto-merge"
+              echo "eligible=true" >> $GITHUB_OUTPUT
+            else
+              echo "❌ Major update or downgrade detected - not eligible for auto-merge"
+              echo "eligible=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "❌ Could not parse version numbers from PR title - not eligible for auto-merge"
+            echo "eligible=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Auto-merge if eligible
+        if: steps.elig.outputs.eligible == 'true'
+        run: gh pr --merge --auto "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # looks at the repo root for lock file  pnpm-lock.yaml
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 7
+    labels:
+      - "dependencies"
+    # reviewers: []
+    # assignees: []
+
+    #Group related updates into a single PR
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      eslint-tooling:
+        patterns: 
+          - "eslint*"
+          - "prettier*"
+          - "@types/*"
+      types:
+        patterns:
+          - "@types/*"
+      jest:
+        patterns:
+          - "jest*"
+          - "ts-jest*"
+
+    # Ignore updates to specific dependencies
+    # ignore:
+    #   - dependency-name: "react"
+
+    # Keep our CI workflow deps up to date things like actions/checkout@v3
+  - package-ecosystem: "github-actions"
+    directory: "/"   # looks at the repo root for .github/workflows
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 7
+    labels:
+      - "ci"
+      - "dependencies"
+      


### PR DESCRIPTION
This pull request introduces automated dependency management using Dependabot and sets up a workflow for automatically merging eligible Dependabot pull requests. The main changes include adding a Dependabot configuration file to manage updates for npm and GitHub Actions dependencies, and creating a GitHub Action to auto-merge patch and minor updates from Dependabot bots.

**Dependabot configuration and automation:**

* Added `.github/dependabot.yaml` to configure Dependabot for both npm and GitHub Actions dependencies, including update schedules, grouping related updates, labeling, and limiting open PRs.
* Created `.github/actions/dependabot-auto-merge/action.yml` to define a workflow that automatically merges Dependabot PRs for patch and minor updates after checks and approvals, using version parsing logic to determine eligibility.